### PR TITLE
CI: Local Deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,9 +23,14 @@ jobs:
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -62,9 +67,14 @@ jobs:
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,22 +35,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["cpp", "java", "python"]
+        language: ["java"]
 
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
           egress-policy: audit
-
       - name: Checkout repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@6ac9fc7e8e290bda8fac86290b68e176def71959 # v2.25.8
         with:
           languages: ${{ matrix.language }}
-
       - uses: graalvm/setup-graalvm@2f25c0caae5b220866f732832d5e3e29ff493338 # v1.2.1
         with:
           java-version: '22'
@@ -61,7 +58,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
       - name: "Build: JNA Libraries"
         run: ant dist
-
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@6ac9fc7e8e290bda8fac86290b68e176def71959 # v2.25.8
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["feat/static-graalvm-jni"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["feat/static-graalvm-jni"]
+  schedule:
+    - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["cpp", "java", "python"]
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@6ac9fc7e8e290bda8fac86290b68e176def71959 # v2.25.8
+        with:
+          languages: ${{ matrix.language }}
+
+      - uses: graalvm/setup-graalvm@2f25c0caae5b220866f732832d5e3e29ff493338 # v1.2.1
+        with:
+          java-version: '22'
+          distribution: 'graalvm-community'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Linux requirements
+        run: sudo apt-get -y install texinfo
+      - uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
+      - name: "Build: JNA Libraries"
+        run: ant dist
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@6ac9fc7e8e290bda8fac86290b68e176def71959 # v2.25.8
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout Repository'
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@0efb1d1d84fc9633afcdaad14c485cbbc90ef46c # v2.5.1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,11 +1,3 @@
-# Dependency Review Action
-#
-# This Action will scan dependency manifest files that change as part of a Pull Request,
-# surfacing known-vulnerable versions of the packages declared or updated in the PR.
-# Once installed, if the workflow run is marked as required,
-# PRs introducing known-vulnerable packages will be blocked from merging.
-#
-# Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
 on: [pull_request]
 
@@ -13,14 +5,61 @@ permissions:
   contents: read
 
 jobs:
-  dependency-review:
+  dependency-graph:
     runs-on: ubuntu-latest
+    name: "Dependency Graph"
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
           egress-policy: audit
+      - name: Set up JDK
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'zulu'
+      - name: 'Checkout Repository'
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Linux requirements
+        run: sudo apt-get -y install texinfo
+      - name: Build JNA Libraries
+        run: |
+          ant dist
+      - name: "Submit Dependency Snapshot (JNA)"
+        uses: advanced-security/maven-dependency-submission-action@5d0f9011b55d6268922128af45275986303459c3 # v4.0.3
+        with:
+          directory: build
+          maven-args: '-f pom-jna.xml'
+      - name: "Submit Dependency Snapshot (JNA JPMS)"
+        uses: advanced-security/maven-dependency-submission-action@5d0f9011b55d6268922128af45275986303459c3 # v4.0.3
+        with:
+          directory: build
+          maven-args: '-f pom-jna-jpms.xml'
+      - name: "Submit Dependency Snapshot (JNA GraalVM)"
+        uses: advanced-security/maven-dependency-submission-action@5d0f9011b55d6268922128af45275986303459c3 # v4.0.3
+        with:
+          directory: build
+          maven-args: '-f pom-jna-graalvm.xml'
+      - name: "Submit Dependency Snapshot (JNA Platform)"
+        uses: advanced-security/maven-dependency-submission-action@5d0f9011b55d6268922128af45275986303459c3 # v4.0.3
+        with:
+          directory: build
+          maven-args: '-f pom-jna-platform.xml'
+      - name: "Submit Dependency Snapshot (JNA JPMS Platform)"
+        uses: advanced-security/maven-dependency-submission-action@5d0f9011b55d6268922128af45275986303459c3 # v4.0.3
+        with:
+          directory: build
+          maven-args: '-f pom-jna-platform-jpms.xml'
 
+  dependency-review:
+    runs-on: ubuntu-latest
+    needs: [dependency-graph]
+    name: "Dependency Review"
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
       - name: 'Checkout Repository'
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: 'Dependency Review'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,6 +8,8 @@ jobs:
   dependency-graph:
     runs-on: ubuntu-latest
     name: "Dependency Graph"
+    permissions:
+      contents: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 21
           distribution: 'zulu'
       - name: 'Checkout Repository'
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/graalvm.workflow.yaml
+++ b/.github/workflows/graalvm.workflow.yaml
@@ -38,8 +38,13 @@ jobs:
     name: Test GVM ${{ inputs.java }}, ${{ inputs.runner }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: graalvm/setup-graalvm@v1
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: graalvm/setup-graalvm@2f25c0caae5b220866f732832d5e3e29ff493338 # v1.2.1
         with:
           java-version: '${{ inputs.java }}'
           distribution: 'graalvm-community'
@@ -54,6 +59,6 @@ jobs:
           brew install automake --force
           brew install libtool --force
           brew install texinfo --force
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
       - name: "Build: Native Image"
         run: ant dist && ant install && ant nativeImage && ant nativeRun

--- a/.github/workflows/graalvm.yaml
+++ b/.github/workflows/graalvm.yaml
@@ -21,14 +21,19 @@ jobs:
     name: Test GVM 22, ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: graalvm/setup-graalvm@v1
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: graalvm/setup-graalvm@2f25c0caae5b220866f732832d5e3e29ff493338 # v1.2.1
         with:
           java-version: '22'
           distribution: 'graalvm-community'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Linux requirements
         run: sudo apt-get -y install texinfo
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
       - name: "Build: Native Image"
         run: ant dist && ant install && ant nativeImage && ant nativeRun

--- a/.github/workflows/maven-bundle.yml
+++ b/.github/workflows/maven-bundle.yml
@@ -1,0 +1,39 @@
+name: Maven Bundle
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build-maven-bundle:
+    runs-on: ubuntu-latest
+    name: Maven Bundle
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Set up JDK
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        with:
+          java-version: 21
+          distribution: 'zulu'
+      - name: Linux requirements
+        run: sudo apt-get -y install texinfo
+      - name: Local Build & Deploy
+        run: ant deploy-local
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jna-maven-bundle-${{ github.sha }}
+          path: build/stage
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 1
+          overwrite: true

--- a/.github/workflows/native-libraries-macOS.yaml
+++ b/.github/workflows/native-libraries-macOS.yaml
@@ -17,9 +17,14 @@ jobs:
     name: Build native libraries for mac OS / darwin
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -35,7 +40,7 @@ jobs:
           ant -Dos.prefix=darwin-aarch64
           ant -Dos.prefix=darwin-x86-64
       - name: Upload mac OS binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: darwin-native
           path: |

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,76 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '20 7 * * 2'
+  push:
+    branches: ["feat/static-graalvm-jni"]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - name: "Checkout code"
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecards on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@6ac9fc7e8e290bda8fac86290b68e176def71959 # v2.25.8
+        with:
+          sarif_file: results.sarif

--- a/build.xml
+++ b/build.xml
@@ -81,6 +81,8 @@
   <property name="platform-jpms-jar" value="${dist}/jna-platform-jpms.jar" />
 
   <!-- defined maven snapshots and staging repository id and url -->
+  <property name="maven-local-repository-id" value="local-stage" />
+  <property name="maven-local-repository-url" value="file://${basedir}/build/stage" />
   <property name="maven-snapshots-repository-id" value="oss.sonatype.org" />
   <property name="maven-snapshots-repository-url" value="https://oss.sonatype.org/content/repositories/snapshots/" />
   <property name="maven-staging-repository-id" value="oss.sonatype.org" />
@@ -88,6 +90,7 @@
 
   <!-- Miscellaneous -->
   <property name="build" value="build"/>
+  <property name="build.stage" value="build/stage"/>
   <property name="build.compiler.emacs" value="true"/>
 
   <property name="pom-base" value="pom-jna.xml" />
@@ -237,6 +240,7 @@
     <property name="jni.info" location="${build.headers}/jni.properties"/>
 
     <mkdir dir="${build}"/>
+    <mkdir dir="${build.stage}" />
     <mkdir dir="${build.native}"/>
     <mkdir dir="${build.headers}"/>
     <mkdir dir="${classes}"/>
@@ -1616,6 +1620,64 @@ cd ..
     </artifact:mvn>
   </target>
 
+  <!-- NOTE: The 'deploy-local' target deploys to `build/stage`. -->
+  <target name="deploy-local" depends="dist,-bootstrap-maven" description="deploy to 'build/stage' locally">
+    <artifact:mvn failonerror="true">
+      <arg value="org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy-file"/>
+      <arg value="-Durl=${maven-local-repository-url}"/>
+      <arg value="-DrepositoryId=${maven-local-repository-id}"/>
+      <arg value="-DpomFile=${pom}"/>
+      <arg value="-Dfile=${dist-jar}"/>
+      <arg value="-Dfiles=${maven-sources-jar},${maven-javadoc-jar},${dist-aar}"/>
+      <arg value="-Dtypes=jar,jar,aar"/>
+      <arg value="-Dclassifiers=sources,javadoc,"/>
+    </artifact:mvn>
+
+    <artifact:mvn failonerror="true">
+      <arg value="org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy-file"/>
+      <arg value="-Durl=${maven-local-repository-url}"/>
+      <arg value="-DrepositoryId=${maven-local-repository-id}"/>
+      <arg value="-DpomFile=${pom-platform}"/>
+      <arg value="-Dfile=${platform-jar}"/>
+      <arg value="-Dfiles=${platform-sources-jar},${platform-javadoc-jar}"/>
+      <arg value="-Dtypes=jar,jar"/>
+      <arg value="-Dclassifiers=sources,javadoc"/>
+    </artifact:mvn>
+
+    <artifact:mvn failonerror="true">
+      <arg value="org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy-file"/>
+      <arg value="-Durl=${maven-local-repository-url}"/>
+      <arg value="-DrepositoryId=${maven-local-repository-id}"/>
+      <arg value="-DpomFile=${pom-jpms}"/>
+      <arg value="-Dfile=${dist-jar-jpms}"/>
+      <arg value="-Dfiles=${maven-sources-jar},${maven-javadoc-jar}"/>
+      <arg value="-Dtypes=jar,jar"/>
+      <arg value="-Dclassifiers=sources,javadoc"/>
+    </artifact:mvn>
+
+    <artifact:mvn failonerror="true">
+      <arg value="org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy-file"/>
+      <arg value="-Durl=${maven-local-repository-url}"/>
+      <arg value="-DrepositoryId=${maven-local-repository-id}"/>
+      <arg value="-DpomFile=${pom-graalvm}"/>
+      <arg value="-Dfile=${dist-jar-graalvm}"/>
+      <arg value="-Dfiles=${maven-sources-jar},${maven-javadoc-jar}"/>
+      <arg value="-Dtypes=jar,jar"/>
+      <arg value="-Dclassifiers=sources,javadoc"/>
+    </artifact:mvn>
+
+    <artifact:mvn failonerror="true">
+      <arg value="org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy-file"/>
+      <arg value="-Durl=${maven-local-repository-url}"/>
+      <arg value="-DrepositoryId=${maven-local-repository-id}"/>
+      <arg value="-DpomFile=${pom-platform-jpms}"/>
+      <arg value="-Dfile=${platform-jpms-jar}"/>
+      <arg value="-Dfiles=${platform-sources-jar},${platform-javadoc-jar}"/>
+      <arg value="-Dtypes=jar,jar"/>
+      <arg value="-Dclassifiers=sources,javadoc"/>
+    </artifact:mvn>
+  </target>
+
   <!-- NOTE: The 'deploy' target works only if the version (jna.version in build.xml) ends in '-SNAPSHOT'. -->
   <target name="deploy" depends="dist,-bootstrap-maven" description="deploy snapshot version to Maven snapshot repository">
     <artifact:mvn failonerror="true">
@@ -1759,6 +1821,7 @@ cd ..
           <dependency groupId="org.apache.maven" artifactId="maven-artifact-manager" version="2.0.10" />
           <dependency groupId="org.apache.maven" artifactId="maven-plugin-registry" version="2.0.10" />
           <dependency groupId="org.apache.maven" artifactId="maven-plugin-api" version="2.0.10" />
+          <dependency groupId="org.codehaus.plexus" artifactId="plexus-utils" version="1.5.6" />
           <dependency groupId="org.codehaus.plexus" artifactId="plexus-utils" version="3.0.15" />
       </artifact:dependencies>
       <artifact:dependencies pathId="dependency.dummy2">


### PR DESCRIPTION
## Summary

Adds a job to CI, and a corresponding Ant task (`deploy-local`), which establishes an on-disk Maven repository, and "deploys" JNA artifacts to it; the CI job uploads this as a GitHub Actions artifact.

Downstream projects (like us!) can use this artifact to test snapshot versions of JNA effectively. All they need to do is (1) download a given "Maven bundle," (2) unzip it, and (3) deploy it as expressed into a Maven repository, local or remote.

- [x] Add Ant task for `deploy-local`
- [x] Add CI task for uploading `deploy-local` as an artifact
